### PR TITLE
Fix memory management

### DIFF
--- a/userspace/apps/space_invaders/Sprite.h
+++ b/userspace/apps/space_invaders/Sprite.h
@@ -10,7 +10,6 @@ class Sprite {
 public:
   // Construct a new sprite from bitmap data
   Sprite(const uint32_t data[], uint8_t height, uint8_t width);
-  ~Sprite() { delete data; }
 
 private:
   uint8_t width;

--- a/userspace/apps/space_invaders/Sprites.cpp
+++ b/userspace/apps/space_invaders/Sprites.cpp
@@ -142,7 +142,7 @@ Sprites::Sprites() {
       new Sprite(sprite_number9_5x5, SPRITES_5X5_ROWS, SPRITES_5X5_COLS);
 }
 
-// Returns the spite for a given character
+// Returns the sprite for a given character
 Sprites::~Sprites() {
   for (auto i : chars)
     delete i.second;
@@ -165,7 +165,7 @@ Sprite *Sprites::getChar(char letter) {
   return chars[letter];
 }
 
-// Returns the spite for a given alien type
+// Returns the sprite for a given alien type
 Sprite *Sprites::getAlien(sprite_alien_type_t alien_type) {
   if (aliens.count(alien_type) == 0)
     return NULL;

--- a/userspace/apps/space_invaders/Sprites.cpp
+++ b/userspace/apps/space_invaders/Sprites.cpp
@@ -142,7 +142,7 @@ Sprites::Sprites() {
       new Sprite(sprite_number9_5x5, SPRITES_5X5_ROWS, SPRITES_5X5_COLS);
 }
 
-// Returns the sprite for a given character
+// destructor for all sprites
 Sprites::~Sprites() {
   for (auto i : chars)
     delete i.second;
@@ -159,6 +159,7 @@ Sprites::~Sprites() {
   delete bunker;
 }
 
+// Returns the sprite for a given character
 Sprite *Sprites::getChar(char letter) {
   if (chars.count(letter) == 0)
     return NULL;

--- a/userspace/apps/space_invaders/Sprites.cpp
+++ b/userspace/apps/space_invaders/Sprites.cpp
@@ -143,6 +143,22 @@ Sprites::Sprites() {
 }
 
 // Returns the spite for a given character
+Sprites::~Sprites() {
+  for (auto i : chars)
+    delete i.second;
+  for (auto i : aliens)
+    delete i.second;
+  for (auto i : tanks)
+    delete i.second;
+  for (auto i : bullets)
+    delete i.second;
+  for (auto i : bunkerDmg)
+    delete i;
+  delete ufo;
+  delete explosion;
+  delete bunker;
+}
+
 Sprite *Sprites::getChar(char letter) {
   if (chars.count(letter) == 0)
     return NULL;

--- a/userspace/apps/space_invaders/Sprites.h
+++ b/userspace/apps/space_invaders/Sprites.h
@@ -37,6 +37,7 @@ typedef enum {
 class Sprites {
 public:
   Sprites();
+  ~Sprites();
 
   // UFO sprite
   Sprite *getUFO() { return ufo; }


### PR DESCRIPTION
# Issues
- Sprites in `Sprites.cpp` are never deleted, causing a memory leak
- Destructor in `Sprite.h` deletes a non-heap object
- Minor spelling errors

# Changes
- loop through all vectors of sprites and delete each sprite
- Remove deconstructor in `Sprite.h`
- "spite" -> "sprite"

# Testing
- Tested on PYNQ board running class iso file, functions well with Space Invaders lab milestone 2